### PR TITLE
ci: run action on merge with main

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,8 +4,9 @@
 name: Node.js Package
 
 on:
-  release:
-    types: [released]
+  push:
+    branches:
+      - main
 
 jobs:
   # Publish to npm


### PR DESCRIPTION
Change action to run on merge with `main` not release 