### PR TITLE
chore: use correct import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ VolumeViewer.defaultProps = {
 
 ```jsx
 import React from 'react'
-import VolumeViewer from 'react-volume-viewer'
+import { VolumeViewer } from "react-volume-viewer";
 
 import haline from "./path/to/colormap/haline.png";
 import model from "./path/to/model.png";


### PR DESCRIPTION
Import is `import { VolumeViewer } from "react-volume-viewer";` not `import VolumeViewer from "react-volume-viewer";`