### PR TITLE
Fix controls state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@reach/tabs": "^0.16.4",
         "aframe": "^1.2.0",
         "d3-scale": "^4.0.2",
+        "lodash": "^4.17.21",
         "rc-slider": "^9.7.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@reach/tabs": "^0.16.4",
     "aframe": "^1.2.0",
     "d3-scale": "^4.0.2",
+    "lodash": "^4.17.21",
     "rc-slider": "^9.7.4"
   },
   "peerDependencies": {

--- a/src/components/AframeScene/AframeScene.jsx
+++ b/src/components/AframeScene/AframeScene.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 
 import "aframe";
 import "../../Aframe/arcball-camera";

--- a/src/components/AframeScene/AframeScene.jsx
+++ b/src/components/AframeScene/AframeScene.jsx
@@ -12,7 +12,6 @@ import "../../Aframe/collider-check";
 import { toAframeString } from "../../utils";
 
 function AframeScene({ models, sliders }) {
-  console.log("SCENE")
   return (
     <a-scene id="volumeViewerScene" background="color: black" embedded>
       {/* HAND */}

--- a/src/components/AframeScene/AframeScene.jsx
+++ b/src/components/AframeScene/AframeScene.jsx
@@ -1,4 +1,5 @@
 import React, { memo } from "react";
+import { isEqual } from "lodash"
 
 import "aframe";
 import "../../Aframe/arcball-camera";
@@ -11,6 +12,7 @@ import "../../Aframe/collider-check";
 import { toAframeString } from "../../utils";
 
 function AframeScene({ models, sliders }) {
+  console.log("SCENE")
   return (
     <a-scene id="volumeViewerScene" background="color: black" embedded>
       {/* HAND */}
@@ -94,4 +96,4 @@ function AframeScene({ models, sliders }) {
   );
 }
 
-export default memo(AframeScene);
+export default memo(AframeScene, (prevProps, nextProps) => isEqual(prevProps, nextProps));

--- a/src/components/AframeScene/AframeScene.jsx
+++ b/src/components/AframeScene/AframeScene.jsx
@@ -8,9 +8,10 @@ import "../../Aframe/render-2d-clipplane";
 import "../../Aframe/entity-collider-check";
 import "../../Aframe/collider-check";
 
-import { toAframeString } from "../../utils"
+import { toAframeString } from "../../utils";
 
 function AframeScene({ models, sliders }) {
+  console.log("SCENE", models);
   return (
     <a-scene id="volumeViewerScene" background="color: black" embedded>
       {/* HAND */}

--- a/src/components/AframeScene/AframeScene.jsx
+++ b/src/components/AframeScene/AframeScene.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { memo } from "react";
 
 import "aframe";
 import "../../Aframe/arcball-camera";
@@ -11,7 +12,6 @@ import "../../Aframe/collider-check";
 import { toAframeString } from "../../utils";
 
 function AframeScene({ models, sliders }) {
-  console.log("SCENE", models);
   return (
     <a-scene id="volumeViewerScene" background="color: black" embedded>
       {/* HAND */}
@@ -95,4 +95,4 @@ function AframeScene({ models, sliders }) {
   );
 }
 
-export default AframeScene;
+export default memo(AframeScene);

--- a/src/components/AframeScene/AframeScene.jsx
+++ b/src/components/AframeScene/AframeScene.jsx
@@ -95,4 +95,4 @@ function AframeScene({ models, sliders }) {
   );
 }
 
-export default memo(AframeScene, (prevProps, nextProps) => isEqual(prevProps, nextProps));
+export default memo(AframeScene, isEqual);

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -16,8 +16,6 @@ function Controls({
   setSliders,
   reset,
 }) {
-  // TODO: Test ColorMap controls
-  console.log(controlsVisible);
   return (
     <Wrapper $visible={controlsVisible}>
       <StyledTabList>

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -7,10 +7,19 @@ import ColorMapControls from "../ColorMapControls";
 import OpacityControls from "../OpacityControls";
 import ClipControls from "../ClipControls";
 
-function Controls({ models, sliders, setModels, setSliders, reset }) {
+// function Controls({ models, sliders, setModels, setSliders, reset }) {
+function Controls({
+  controlsVisible,
+  models,
+  sliders,
+  setModels,
+  setSliders,
+  reset,
+}) {
   // TODO: Test ColorMap controls
+  console.log(controlsVisible);
   return (
-    <Wrapper>
+    <Wrapper $visible={controlsVisible}>
       <StyledTabList>
         {models.map((model) => (
           <Tab key={model.name}>{model.name}</Tab>
@@ -54,6 +63,7 @@ const Wrapper = styled(Tabs)`
   height: fit-content;
   max-height: calc(100% - 16px); // Leaves 8px to the bottom of the AframeScene
   overflow: auto;
+  display: ${(props) => (props.$visible ? "initial" : "none")};
 `;
 
 // TODO: Cleaner way than just the scrollbar

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -7,7 +7,6 @@ import ColorMapControls from "../ColorMapControls";
 import OpacityControls from "../OpacityControls";
 import ClipControls from "../ClipControls";
 
-// function Controls({ models, sliders, setModels, setSliders, reset }) {
 function Controls({
   controlsVisible,
   models,

--- a/src/components/Controls/Controls.jsx
+++ b/src/components/Controls/Controls.jsx
@@ -8,15 +8,9 @@ import OpacityControls from "../OpacityControls";
 import ClipControls from "../ClipControls";
 
 function Controls({ models, sliders, setModels, setSliders, reset }) {
-  // Keep track of currently open model
-  const [tabIndex, setTabIndex] = React.useState(0);
-  const handleTabsChange = (index) => {
-    setTabIndex(index);
-  };
-
-  // TODO: Each individual Tab/TabPanel should only updated when the specific model changes
+  // TODO: Test ColorMap controls
   return (
-    <Wrapper index={tabIndex} onChange={handleTabsChange}>
+    <Wrapper>
       <StyledTabList>
         {models.map((model) => (
           <Tab key={model.name}>{model.name}</Tab>
@@ -24,18 +18,18 @@ function Controls({ models, sliders, setModels, setSliders, reset }) {
       </StyledTabList>
 
       <StyledTabPanels>
-        {models.map((model) => (
+        {models.map((model, idx) => (
           <TabPanel key={model.name}>
             <ColorMapControls
               model={model}
-              modelIdx={tabIndex}
+              modelIdx={idx}
               setModels={setModels}
             />
 
             {model.useTransferFunction && (
               <OpacityControls
                 initTransferFunction={model.initTransferFunction}
-                modelIdx={tabIndex}
+                modelIdx={idx}
                 range={model.range}
                 setModels={setModels}
               />

--- a/src/components/OpacityControls/OpacityControls.jsx
+++ b/src/components/OpacityControls/OpacityControls.jsx
@@ -42,7 +42,6 @@ function getRelativeMousePos(e) {
 
 function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
   const canvasRef = useRef(null);
-  const readyToDraw = useRef(false);
   const [cursorType, setCursorType] = useState("pointer"); // Cursor type (styled-components)
   const [canvasPoints, setCanvasPoints] = useState([]); // Points in canvas space
   const [pointHovering, setPointHovering] = useState(null); // The point currently moused over
@@ -51,7 +50,6 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
   /** INITIAL RENDER **/
 
   useEffect(() => {
-    readyToDraw.current = false;
     const canvas = canvasRef.current;
 
     // Set ranges and transformations
@@ -65,7 +63,6 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
       .range(canvasRange.y);
 
     // Initialize canvasPoints
-    // console.log("INIT", modelIdx, initTransferFunction);
     setCanvasPoints(
       initTransferFunction.map((p) => {
         return {
@@ -74,7 +71,6 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
         };
       })
     );
-    return () => (readyToDraw.current = true);
   }, [initTransferFunction]);
 
   /** DRAW FUNCTION **/
@@ -113,7 +109,6 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
       context.fill();
     });
 
-    console.log("DRAW", modelIdx, canvasPoints);
     setModels((models) => [
       ...models.slice(0, modelIdx),
       {

--- a/src/components/OpacityControls/OpacityControls.jsx
+++ b/src/components/OpacityControls/OpacityControls.jsx
@@ -63,6 +63,7 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
       .range(canvasRange.y);
 
     // Initialize canvasPoints
+    console.log("INIT", modelIdx, initTransferFunction);
     setCanvasPoints(
       initTransferFunction.map((p) => {
         return {
@@ -108,6 +109,7 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
       context.fill();
     });
 
+    console.log("DRAW", modelIdx, canvasPoints);
     setModels((models) => [
       ...models.slice(0, modelIdx),
       {

--- a/src/components/OpacityControls/OpacityControls.jsx
+++ b/src/components/OpacityControls/OpacityControls.jsx
@@ -42,6 +42,7 @@ function getRelativeMousePos(e) {
 
 function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
   const canvasRef = useRef(null);
+  const readyToDraw = useRef(false);
   const [cursorType, setCursorType] = useState("pointer"); // Cursor type (styled-components)
   const [canvasPoints, setCanvasPoints] = useState([]); // Points in canvas space
   const [pointHovering, setPointHovering] = useState(null); // The point currently moused over
@@ -50,6 +51,7 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
   /** INITIAL RENDER **/
 
   useEffect(() => {
+    readyToDraw.current = false;
     const canvas = canvasRef.current;
 
     // Set ranges and transformations
@@ -63,7 +65,7 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
       .range(canvasRange.y);
 
     // Initialize canvasPoints
-    console.log("INIT", modelIdx, initTransferFunction);
+    // console.log("INIT", modelIdx, initTransferFunction);
     setCanvasPoints(
       initTransferFunction.map((p) => {
         return {
@@ -72,10 +74,12 @@ function OpacityControls({ initTransferFunction, modelIdx, range, setModels }) {
         };
       })
     );
+    return () => (readyToDraw.current = true);
   }, [initTransferFunction]);
 
   /** DRAW FUNCTION **/
 
+  // TODO: Don't want to run on renders where the other useEffect runs
   useEffect(() => {
     const canvas = canvasRef.current;
     const context = canvas.getContext("2d");

--- a/src/components/VolumeViewer/VolumeViewer.jsx
+++ b/src/components/VolumeViewer/VolumeViewer.jsx
@@ -32,19 +32,20 @@ function VolumeViewer({
     <Wrapper key={remountKey} className={className} style={style}>
       <AframeScene models={models} sliders={sliders} />
 
-      {controlsVisible && (
-        <Controls
-          models={models}
-          sliders={sliders}
-          setModels={setModels}
-          setSliders={setSliders}
-          reset={() => {
-            setModels(buildModels(modelsProp));
-            setSliders(DEFAULT_SLIDERS);
-            setRemountKey(Math.random());
-          }}
-        />
-      )}
+      {/* {controlsVisible && ( */}
+      <Controls
+        controlsVisible={controlsVisible}
+        models={models}
+        sliders={sliders}
+        setModels={setModels}
+        setSliders={setSliders}
+        reset={() => {
+          setModels(buildModels(modelsProp));
+          setSliders(DEFAULT_SLIDERS);
+          setRemountKey(Math.random());
+        }}
+      />
+      {/* )} */}
     </Wrapper>
   );
 }

--- a/src/components/VolumeViewer/VolumeViewer.jsx
+++ b/src/components/VolumeViewer/VolumeViewer.jsx
@@ -32,7 +32,6 @@ function VolumeViewer({
     <Wrapper key={remountKey} className={className} style={style}>
       <AframeScene models={models} sliders={sliders} />
 
-      {/* {controlsVisible && ( */}
       <Controls
         controlsVisible={controlsVisible}
         models={models}
@@ -45,7 +44,6 @@ function VolumeViewer({
           setRemountKey(Math.random());
         }}
       />
-      {/* )} */}
     </Wrapper>
   );
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -92,6 +92,6 @@ function toAframeString(obj) {
     str += `${key}: ${val};`;
   });
   return str;
-};
+}
 
 export { validateModels, buildModels, useModelsPropMemo, toAframeString };


### PR DESCRIPTION
Was accidentally passing the tab index (the current model open in the `Controls`) instead of the model's index (of the `models` array) into `ColorMapControls` and `OpacityControls`. This was causing `setModels` to update the wrong model Some additional performance changes too.

- Pass correct index into `ColorMapControls` and `OpacityControls`
- Memoizes `AframeScene` (no longer re-renders when `controlsVisible` changes)
- Keep `<Controls />` on the ReactDOM at all times (prevents unnecessary re-initialization of state)