### PR TITLE
Add link to example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Run `npm start` in one terminal and `cd example && npm start` in a second termin
 npm install react-volume-viewer
 ```
 
+## Example
+
+An example project can be found on the [GitHub Page](https://brown-ccv.github.io/react-volume-viewer/) of this repo.
+
 ## Props
 
 The only required props are the model's path, name, and its minimum and maximum data points. The model's path should be imported into the project and passed in from there - see the [example project](#example).


### PR DESCRIPTION
Adds a link to the deployed example app. This is done through GitHub Pages