### PR TITLE
fix: error when no enabled models

### DIFF
--- a/src/aframe/volume.js
+++ b/src/aframe/volume.js
@@ -204,23 +204,7 @@ AFRAME.registerComponent("volume", {
       )
     ).then((promises) => {
       const { values: modelStructs, errors } = partitionPromises(promises);
-
-      // Validate all model textures are the same size
-      const { width, height } = modelStructs[0].modelTexture.image;
-      modelStructs.forEach(({ name, modelTexture }) => {
-        if (
-          !(
-            modelTexture.image.width === width &&
-            modelTexture.image.height === height
-          )
-        ) {
-          errors.push(
-            new Error(
-              "Model '" + name + "' does not match size " + width + "x" + height
-            )
-          );
-        }
-      });
+      errors.push(...this.validateModelTextureSizes(modelStructs));
 
       // Bubble loading errors up to AframeScene
       errors.length &&
@@ -353,5 +337,29 @@ AFRAME.registerComponent("volume", {
     const transferTexture = new DataTexture(rgbaData, 256, 1, RGBAFormat);
     transferTexture.needsUpdate = true;
     return transferTexture;
+  },
+
+  // Validate all model textures are the same size
+  validateModelTextureSizes: function (modelStructs) {
+    const errors = [];
+    if (modelStructs.length) {
+      const { width, height } = modelStructs[0].modelTexture.image;
+
+      modelStructs.forEach(({ name, modelTexture }) => {
+        if (
+          !(
+            modelTexture.image.width === width &&
+            modelTexture.image.height === height
+          )
+        ) {
+          errors.push(
+            new Error(
+              "Model '" + name + "' does not match size " + width + "x" + height
+            )
+          );
+        }
+      });
+    }
+    return errors;
   },
 });

--- a/src/components/AframeScene/AframeScene.jsx
+++ b/src/components/AframeScene/AframeScene.jsx
@@ -25,7 +25,7 @@ function AframeScene({
   useEffect(() => {
     const handler = (error) => {
       const messages = error.detail.map((e) => {
-        console.error(e)
+        console.error(e);
         if (e.cause) return e.message + ". " + e.cause.message;
         else return e.message;
       });
@@ -94,9 +94,7 @@ function AframeScene({
         <Error>
           <ul>
             {errors.map((e) => (
-              <li key={e}>
-                {e}
-              </li>
+              <li key={e}>{e}</li>
             ))}
           </ul>
         </Error>


### PR DESCRIPTION
Fixes a validation error that was occurring when no enabled models were passed to `aframe` and refactors the code into its own function.

