### PR TITLE
Remove Blending.None type

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ CSS styling for the height must be provided, otherwise the height of the compone
 VolumeViewer.propTypes = {
   /**
    * Blending enum
-   *  None: Don't apply any blending - always display first model
-   *  Max: Take maximum value when blending
+   *  Max: Take maximum value at the given point
+   *  Min: Take minimum value at the given point
+   *  Average: Average all models at each point
    */
   blending: PropTypes.oneOf(Object.values(Blending)),
 
@@ -122,7 +123,16 @@ VolumeViewer.defaultProps = {
 
 ## Blending
 
-The `Blending` object is used as an enum for the different algorithms that can be used to blending the models together. `Blending.None` does not apply any blending. `Blending.Max` uses the maximum value between the models.
+The `Blending` object is used as an enum for the different algorithms that can be used to blending the models together.
+
+```js
+const Blending = {
+  Max: 0,
+  Min: 1,
+  Average: 2,
+};
+
+```
 
 ### COLOR_MAPS
 

--- a/src/aframe/fragment-shader.frag
+++ b/src/aframe/fragment-shader.frag
@@ -142,23 +142,20 @@ void main() {
         if(model_structs[0].use) {
             volume_sample = sample_model(model_structs[0], data_position);
 
-            // Blending.None -> just use first model
-            if(blending != 0) {
-                #pragma unroll_loop_start
-                for(int i = 1; i < 4; i++) {
-                    if(model_structs[i].use) {
-                        if(blending == 1) { // Blending.Max
-                            mix_factor = max(volume_sample.a, model_sample.a);
-                        } 
-                        else if(blending == 2) {} // TODO: Blending.Average (115)
-
-                        // Sample model and mix in to volume
-                        model_sample = sample_model(model_structs[i], data_position);
-                        volume_sample = mix(volume_sample, model_sample, mix_factor);
-                    }
+            #pragma unroll_loop_start
+            for(int i = 1; i < 4; i++) {
+                if(model_structs[i].use) {
+                    if(blending == 0) { // Blending.Max
+                        mix_factor = max(volume_sample.a, model_sample.a);
+                    } 
+                    else if(blending == 1) {} // TODO: Blending.Min (127)
+                    else if(blending == 2) {} // TODO: Blending.Average (115)
+                    // Sample model and mix in to volume
+                    model_sample = sample_model(model_structs[i], data_position);
+                    volume_sample = mix(volume_sample, model_sample, mix_factor);
                 }
-                #pragma unroll_loop_end
             }
+                #pragma unroll_loop_end
         } else break; // array is "empty", leave vFragColor transparent
 
         // Blending (front to back)

--- a/src/components/VolumeViewer/VolumeViewer.jsx
+++ b/src/components/VolumeViewer/VolumeViewer.jsx
@@ -93,8 +93,9 @@ const Wrapper = styled.div`
 VolumeViewer.propTypes = {
   /**
    * Blending enum exposed to the user
-   *  None: Don't apply any blending - always display first model
-   *  Max: Take maximum value when blending
+   *  Max: Take maximum value at the given point
+   *  Min: Take minimum value at the given point
+   *  Average: Average all models at each point
    */
   blending: PropTypes.oneOf(Object.values(Blending)),
 
@@ -133,7 +134,7 @@ VolumeViewer.propTypes = {
 };
 
 VolumeViewer.defaultProps = {
-  blending: Blending.None,
+  blending: Blending.Max,
   controlsVisible: false,
   position: DEFAULT_POSITION,
   rotation: DEFAULT_ROTATION,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -28,12 +28,14 @@ const COLOR_MAPS = (() => {
 
 /**
  * Blending enum exposed to the user
- *  None: Don't apply any blending
- *  Add: Apply additive blending
+ *  Max: Take maximum value at the given point
+ *  Min: Take minimum value at the given point
+ *  Average: Average all models at each point
  */
 const Blending = {
-  None: 0,
-  Max: 1,
+  Max: 0,
+  Min: 1,
+  Average: 2,
 };
 
 /** DEFAULT VALUES */


### PR DESCRIPTION
- Remove `Blending.None`
- Add boiler place for `Blending.Average` and `Blending.Min` (#115 and #127)
- closes issue #128 