### PR TITLE
Use max texture size for zScale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-volume-viewer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Aframe container with custom controls for use in react applications",
   "author": "brown-ccv",
   "license": "MIT",


### PR DESCRIPTION
- Removes `validateModelTextureSizes` function
- Uses maximum width and height to determine `zScale`
- closes issue #134 